### PR TITLE
Jay dev 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .idea/
 .__DS_STORE__
+.vscode

--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -15,7 +15,7 @@ int RiskTracker::updateRisk() {
             runningSum -= (x.price * x.quantity);
         }
     }
-    this->totalRisk += runningSum;
+    this->totalRisk = runningSum;
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,17 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, TrackerMultipleTest){
+    std::vector<Trade> trackedTrades;
+    RiskTracker riskTracker(0, trackedTrades);
+    riskTracker.addTrade(Trade(7, false, 1.4));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), -9.8, 1e-4);
+    riskTracker.addTrade(Trade(7, false, 1.6));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), -21, 1e-4);
+    riskTracker.addTrade(Trade(44, true, 2.3));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 80.2, 1e-4);
+}


### PR DESCRIPTION
- This PR fixes the risk tracking bug that was causing the risk calculations to be off when recalculating the risk multiple times after adding numerous trades
- The risk calculating function was changed such that totalSum now equals the runningSum, instead of adding runningSum to totalSum.
- The program was adding trades that were already present in the trade list again when calculating the sum, rather than adding just the newly added trades.
- Instead of attempting to track trades added since the last risk calculation update, the entire risk sum is recalculated.
- It was initially a struggle understanding what the code was doing as well as getting used to the development environment.
- Recalculating the entire total risk from scratch each time I want to update seems inefficient, so in the future it would be best to find a smarter way of updating the risk.